### PR TITLE
Fix connection failure when sending too many environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+* Fix connection failure when sending too many environment variables (fix [#22](https://github.com/moul/sshportal/issues/22))
 * Fix panic when entering empty command (fix [#13](https://github.com/moul/sshportal/issues/13))
 
 ## v1.6.0 (2017-12-12)

--- a/vendor/github.com/gliderlabs/ssh/session.go
+++ b/vendor/github.com/gliderlabs/ssh/session.go
@@ -90,7 +90,7 @@ func sessionHandler(srv *Server, conn *gossh.ServerConn, newChan gossh.NewChanne
 		conn:       conn,
 		handler:    srv.Handler,
 		ptyCb:      srv.PtyCallback,
-		maskedReqs: make(chan *gossh.Request, 5),
+		maskedReqs: make(chan *gossh.Request, 100),
 		ctx:        ctx,
 	}
 	sess.handleRequests(reqs)


### PR DESCRIPTION
Fix #22 

*Temporary fix*

A better solution requires a refactor of the ssh session handler (related with #24)

Related with this comment: https://github.com/gliderlabs/ssh/issues/47#issuecomment-340550104