### PR TITLE
Dynamic username for the first created account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-* No entry
+* The default created user now has the same username as the user starting sshportal (was hardcoded "admin")
 
 ## v1.7.1 (2018-01-03)
 

--- a/dbinit.go
+++ b/dbinit.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/user"
+	"strings"
 	"time"
 
 	"github.com/go-gormigrate/gormigrate"
@@ -522,9 +524,20 @@ func dbInit(db *gorm.DB) error {
 		if err := db.Where("name = ?", "admin").First(&adminRole).Error; err != nil {
 			return err
 		}
+		var username string
+		if currentUser, err := user.Current(); err == nil {
+			username = currentUser.Username
+		}
+		if username == "" {
+			username = os.Getenv("USER")
+		}
+		username = strings.ToLower(username)
+		if username == "" {
+			username = "admin" // fallback username
+		}
 		user := User{
-			Name:        "admin",
-			Email:       "admin@sshportal",
+			Name:        username,
+			Email:       fmt.Sprintf("%s@localhost", username),
 			Comment:     "created by sshportal",
 			Roles:       []*UserRole{&adminRole},
 			InviteToken: inviteToken,


### PR DESCRIPTION
The default created user now has the same username as the user starting sshportal (was hardcoded admin)