### PR TITLE
Add log for exec request.

### DIFF
--- a/pkg/bastionsession/bastionsession.go
+++ b/pkg/bastionsession/bastionsession.go
@@ -80,6 +80,11 @@ func pipe(lreqs, rreqs <-chan *gossh.Request, lch, rch gossh.Channel, logsLocati
 				return nil
 			}
 			b, err := rch.SendRequest(req.Type, req.WantReply, req.Payload)
+			if req.Type == "exec" {
+				command := append(req.Payload, []byte("\n")...)
+				wrappedlch.LogWrite(command)
+			}
+			
 			if err != nil {
 				return err
 			}

--- a/vendor/github.com/arkan/bastion/pkg/logchannel/logchannel.go
+++ b/vendor/github.com/arkan/bastion/pkg/logchannel/logchannel.go
@@ -42,6 +42,11 @@ func (l *logChannel) Write(data []byte) (int, error) {
 	return l.channel.Write(data)
 }
 
+func (l *logChannel) LogWrite(data []byte) (int, error) {
+	writeTTYRecHeader(l.writer, len(data))
+	return l.writer.Write(data)
+}
+
 func (l *logChannel) Close() error {
 	l.writer.Close()
 


### PR DESCRIPTION
Add log for exec request.

This deals with session opened with:
ssh bastion -l host1 "rm -rf > /dev/null 2>&1 " which was not audited.

This PR depends on https://github.com/arkan/bastion/pull/4. 