### PR TITLE
Implement proxied connections

### DIFF
--- a/db.go
+++ b/db.go
@@ -63,6 +63,8 @@ type Host struct {
 	HostKey  []byte       `sql:"size:10000" valid:"optional"`
 	Groups   []*HostGroup `gorm:"many2many:host_host_groups;"`
 	Comment  string       `valid:"optional"`
+	Hop      *Host
+	HopID    uint
 }
 
 // UserKey defines a user public key used by sshportal to identify the user

--- a/dbinit.go
+++ b/dbinit.go
@@ -458,6 +458,30 @@ func dbInit(db *gorm.DB) error {
 			Rollback: func(tx *gorm.DB) error {
 				return fmt.Errorf("not implemented")
 			},
+		}, {
+			ID: "29",
+			Migrate: func(tx *gorm.DB) error {
+				type Host struct {
+					// FIXME: use uuid for ID
+					gorm.Model
+					Name     string `gorm:"size:32"`
+					Addr     string
+					User     string
+					Password string
+					URL      string
+					SSHKey   *SSHKey      `gorm:"ForeignKey:SSHKeyID"`
+					SSHKeyID uint         `gorm:"index"`
+					HostKey  []byte       `sql:"size:10000"`
+					Groups   []*HostGroup `gorm:"many2many:host_host_groups;"`
+					Comment  string
+					Hop      *Host
+					HopID    uint
+				}
+				return tx.AutoMigrate(&Host{}).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return fmt.Errorf("not implemented")
+			},
 		},
 	})
 	if err := m.Migrate(); err != nil {

--- a/ssh.go
+++ b/ssh.go
@@ -113,16 +113,33 @@ func channelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewCh
 
 		switch host.Scheme() {
 		case BastionSchemeSSH:
-			clientConfig, err := bastionClientConfig(ctx, host)
-			if err != nil {
-				ch, _, err2 := newChan.Accept()
+			sessionConfigs := make([]bastionsession.Config, 0)
+			currentHost := host
+			for currentHost != nil {
+				clientConfig, err2 := bastionClientConfig(ctx, currentHost)
 				if err2 != nil {
+					ch, _, err3 := newChan.Accept()
+					if err3 != nil {
+						return
+					}
+					fmt.Fprintf(ch, "error: %v\n", err2)
+					// FIXME: force close all channels
+					_ = ch.Close()
 					return
 				}
-				fmt.Fprintf(ch, "error: %v\n", err)
-				// FIXME: force close all channels
-				_ = ch.Close()
-				return
+				sessionConfigs = append([]bastionsession.Config{{
+					Addr:         currentHost.DialAddr(),
+					ClientConfig: clientConfig,
+					Logs:         actx.config.logsLocation,
+				}}, sessionConfigs...)
+				if currentHost.HopID != 0 {
+					var newHost Host
+					actx.db.Model(currentHost).Related(&newHost, "HopID")
+					hostname := newHost.Name
+					currentHost, _ = HostByName(actx.db, hostname)
+				} else {
+					currentHost = nil
+				}
 			}
 
 			sess := Session{
@@ -140,11 +157,7 @@ func channelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewCh
 				return
 			}
 
-			err = bastionsession.ChannelHandler(srv, conn, newChan, ctx, bastionsession.Config{
-				Addr:         host.DialAddr(),
-				ClientConfig: clientConfig,
-				Logs:         actx.config.logsLocation,
-			})
+			err = bastionsession.MultiChannelHandler(srv, conn, newChan, ctx, sessionConfigs)
 
 			now := time.Now()
 			sessUpdate := Session{


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR allows admins to define a "hop" when creating a server (typically needed when a machine is inside a walled network, with only one entrypoint).

The feature is implemented as follows:
- when creating a host, there is a possiblity to add a "hop"
- hops are referend them with the name of the host in sshportal
- the hop ID is then saved in the DB in the hosts table
- when connecting to a host, sshportal will recurse through all the possible hops of a host (allowing chained proxies)

**Special notes for your reviewer**:

I don’t know if this feature is wanted, but we found it quite useful. I couldn't find a contributing guide, but I'm of course open to any code change that may be needed to properly integrate this code in the project.