### PR TITLE
Show 'n/a' in case of missing information to avoid crashing.

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -1862,9 +1862,15 @@ GLOBAL OPTIONS:
 						table.SetBorder(false)
 						table.SetCaption(true, fmt.Sprintf("Total: %d userkeys.", len(userKeys)))
 						for _, userkey := range userKeys {
+							var email string
+							if userkey.User != nil {
+									email = userkey.User.Email
+							} else {
+									email = "n/a"
+							}
 							table.Append([]string{
 								fmt.Sprintf("%d", userkey.ID),
-								userkey.User.Email,
+								email,
 								// FIXME: add fingerprint
 								humanize.Time(userkey.UpdatedAt),
 								humanize.Time(userkey.CreatedAt),
@@ -1961,10 +1967,22 @@ GLOBAL OPTIONS:
 								duration = humanize.RelTime(session.CreatedAt, *session.StoppedAt, "", "")
 							}
 							duration = strings.Replace(duration, "now", "1 second", 1)
+							var hostname string
+							if session.Host != nil {
+									hostname = session.Host.Name
+							} else {
+									hostname = "n/a"
+							}
+							var username string
+							if session.User != nil {
+									username = session.User.Name
+							} else {
+									username = "n/a"
+							}
 							table.Append([]string{
 								fmt.Sprintf("%d", session.ID),
-								session.User.Name,
-								session.Host.Name,
+								username,
+								hostname,
 								session.Status,
 								humanize.Time(session.CreatedAt),
 								duration,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR shows 'n/a' in the appropriate field in cases of missing user or host when doing a `session ls` or `userkey ls`, thus avoiding a crash if listing sessions or userkeys after removing the host or user they reference.

**Which issue this PR fixes**: fixes #53 (`userkey ls` crashes) and also some `session ls` crashes.

**Special notes for your reviewer**:

Not sure this is the right way to fix this. Maybe userkeys should juste be removed alongside the associated user as there doesn't seem to be a point to keeping them around ? Also maybe database constraints should be added to avoid breaking relations ? Don't hesitate to tell me and I will look into modifying the PR accordingly.