### PR TITLE
WIP feat: add LDAP invite functionality

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,8 @@ type configServe struct {
 	bindAddr        string
 	debug, demo     bool
 	idleTimeout     time.Duration
+	ldapServer      string
+	ldapBase        string
 }
 
 func parseServeConfig(c *cli.Context) (*configServe, error) {
@@ -27,6 +29,8 @@ func parseServeConfig(c *cli.Context) (*configServe, error) {
 		demo:         c.Bool("demo"),
 		logsLocation: c.String("logs-location"),
 		idleTimeout:  c.Duration("idle-timeout"),
+		ldapServer:   c.String("ldap-server"),
+		ldapBase:     c.String("ldap-base"),
 	}
 	switch len(ret.aesKey) {
 	case 0, 16, 24, 32:

--- a/main.go
+++ b/main.go
@@ -85,6 +85,14 @@ func main() {
 					Value: 0,
 					Usage: "Duration before an inactive connection is timed out (0 to disable)",
 				},
+				cli.StringFlag{
+					Name:  "ldap-server",
+					Usage: "Hostname of the LDAP server",
+				},
+				cli.StringFlag{
+					Name:  "ldap-base",
+					Usage: "Base DN for LDAP queries",
+				},
 			},
 		}, {
 			Name:   "healthcheck",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,6 +63,12 @@
 			"revisionTime": "2017-01-02T12:52:26Z"
 		},
 		{
+			"checksumSHA1": "KGAX0C/36vHJiw04Nrm3rohzW00=",
+			"path": "github.com/jtblin/go-ldap-client",
+			"revision": "b73f66626b33ca4ac4fd6558efbb062c4fe4e52c",
+			"revisionTime": "2017-02-23T12:19:19Z"
+		},
+		{
 			"checksumSHA1": "gGDSJToIqPYPEnKst2qLfuTeIZU=",
 			"path": "github.com/kr/pty",
 			"revision": "2c10821df3c3cf905230d078702dfbe9404c9b23",
@@ -175,6 +181,18 @@
 			"path": "golang.org/x/sys/windows",
 			"revision": "95c6576299259db960f6c5b9b69ea52422860fce",
 			"revisionTime": "2017-10-30T10:08:44Z"
+		},
+		{
+			"checksumSHA1": "xsaHqy6/sonLV6xIxTNh4FfkWbU=",
+			"path": "gopkg.in/asn1-ber.v1",
+			"revision": "379148ca0225df7a432012b8df0355c2a2063ac0",
+			"revisionTime": "2017-05-11T16:59:59Z"
+		},
+		{
+			"checksumSHA1": "IElTu6wDmpCv8h3JPXAHjuy0Gb8=",
+			"path": "gopkg.in/ldap.v2",
+			"revision": "bb7a9ca6e4fbc2129e3db588a34bc970ffe811a9",
+			"revisionTime": "2017-11-23T04:56:18Z"
 		}
 	],
 	"rootPath": "github.com/moul/sshportal"


### PR DESCRIPTION
This PR adds functionality to invite via LDAP in addition to the invite string. These changes don't allow login via SSH, only processing the invite. To invite a user via ldap, do the following:

- `user invite test`
- `ssh -P 2222 test@localhost`
- input the password
- the ssh key is now associated with the user

Note this PR is a work in progress (WIP). I need to do some more refactoring and testing before being confident in a merge. Feedback would be appreciated.