### PR TITLE
[FIX] unsetting hop on host

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -926,8 +926,9 @@ GLOBAL OPTIONS:
 							// remove the hop
 							if c.Bool("unset-hop") {
 								var hopHost Host
+
 								db.Model(&host).Related(&hopHost, "HopID")
-								if err := model.Association("Hop").Delete(hopHost).Error; err != nil {
+								if err := model.Association("Hop").Clear().Error; err != nil {
 									tx.Rollback()
 									return err
 								}


### PR DESCRIPTION
**Which issue this PR fixes**

* Commit [`101b363`](https://github.com/vdaviot/sshportal/commit/101b363eea3063c70d73d854f3a173ffab4a1fee) fixes:
	* [`#70`](https://github.com/moul/sshportal/issues/70): Unsetting a hop from a host unsets the hops from all the hosts it is set on

**What this PR does / why we need it**

The command ``host update --unset-hop <host>`` removed the host's hop from every hosts and not only the given one.
It now remove the hop only on the given host.
