### PR TITLE
[FIX] Session ls on big databases 

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -163,19 +163,19 @@ func channelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewCh
 				if err != nil {
 					log.Printf("Error: %v", err)
 				}
-			}()
 
-			now := time.Now()
-			sessUpdate := Session{
-				Status:    SessionStatusClosed,
-				ErrMsg:    fmt.Sprintf("%v", err),
-				StoppedAt: &now,
-			}
-			switch sessUpdate.ErrMsg {
-			case "lch closed the connection", "rch closed the connection":
-				sessUpdate.ErrMsg = ""
-			}
-			actx.db.Model(&sess).Updates(&sessUpdate)
+				now := time.Now()
+				sessUpdate := Session{
+					Status:    SessionStatusClosed,
+					ErrMsg:    fmt.Sprintf("%v", err),
+					StoppedAt: &now,
+				}
+				switch sessUpdate.ErrMsg {
+				case "lch closed the connection", "rch closed the connection":
+					sessUpdate.ErrMsg = ""
+				}
+				actx.db.Model(&sess).Updates(&sessUpdate)
+			}()
 		case BastionSchemeTelnet:
 			tmpSrv := ssh.Server{
 				// PtyCallback: srv.PtyCallback,


### PR DESCRIPTION
**Which issue this PR fixes**

* Commit [`251ab85`](https://github.com/vdaviot/sshportal/commit/251ab85702f324e49b6f57fcf7219ea9b338d9bb) fixes:
	* [`#71`](https://github.com/moul/sshportal/issues/71): session ls fails with "Error 1390: Prepared statement contains too many placeholders"
		* Also contains fixes for: [`#72`](https://github.com/moul/sshportal/issues/72) and [`#62`](https://github.com/moul/sshportal/issues/62) ([`1695d4f`](https://github.com/vdaviot/sshportal/commit/1695d4f0b8ae388816abc6d71851a1730fe661fe)) as they are mandatory to test.

**What this PR does / why we need it**

If the mySQL database held too many records, the ``session ls`` command failed with an error message. The hard limit of records by query in mySQL is  65,535.
It now queries by batch of 60000 to solve the problem.

I also added an option to only list active session (--active, -a) to compensate for the increased time taken by the query on bigger databases.

