### PR TITLE
Fix userkey create.

### DIFF
--- a/db.go
+++ b/db.go
@@ -70,7 +70,7 @@ type Host struct {
 // UserKey defines a user public key used by sshportal to identify the user
 type UserKey struct {
 	gorm.Model
-	Key           []byte `sql:"size:10000" valid:"required,length(1|10000)"`
+	Key           []byte `sql:"size:10000" valid:"length(1|10000)"`
 	AuthorizedKey string `sql:"size:10000" valid:"required,length(1|10000)"`
 	UserID        uint   ``
 	User          *User  `gorm:"ForeignKey:UserID"`

--- a/shell.go
+++ b/shell.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mgutz/ansi"
 	"github.com/moby/moby/pkg/namesgenerator"
 	"github.com/moul/ssh"
+	gossh "golang.org/x/crypto/ssh"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
@@ -1925,9 +1927,10 @@ GLOBAL OPTIONS:
 						}
 
 						userkey := UserKey{
-							User:    &user,
-							Key:     key.Marshal(),
-							Comment: comment,
+							User:          &user,
+							Key:           key.Marshal(),
+							Comment:       comment,
+							AuthorizedKey: string(gossh.MarshalAuthorizedKey(key)),
 						}
 						if c.String("comment") != "" {
 							userkey.Comment = c.String("comment")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
`echo "ssh-rsa key ..." | ssh localhost -p 2222 -l admin userkey create` shawn
Without the PR, it shows `error: Key: non zero value required;AuthorizedKey: non zero value required;`
For the AuthorizedKey, I compared the code in ssh.go, I thought it might be missing.

For the Key, it is a []byte field. The required valid cause Key: non zero value required.

**Which issue this PR fixes**: fixes #xxx, fixes #xxx...
fixes #46 
**Special notes for your reviewer**:

```diff
--- a/db.go
+++ b/db.go
@@ -70,7 +70,7 @@ type Host struct {
 // UserKey defines a user public key used by sshportal to identify the user
 type UserKey struct {
        gorm.Model
-       Key           []byte `sql:"size:10000" valid:"required,length(1|10000)"`
+       Key           []byte `sql:"size:10000" valid:"length(1|10000)"` // FIXME
        AuthorizedKey string `sql:"size:10000" valid:"required,length(1|10000)"`
        UserID        uint   ``
        User          *User  `gorm:"ForeignKey:UserID"`
(END)
```
