### PR TITLE
[FIX] Format of id in new session | Closing channel if host unreachable

### DIFF
--- a/pkg/bastion/session.go
+++ b/pkg/bastion/session.go
@@ -47,6 +47,7 @@ func multiChannelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.
 				client = gossh.NewClient(ncc, chans, reqs)
 			}
 			if err != nil {
+				lch.Close() // fix #56
 				return err
 			}
 			defer func() { _ = client.Close() }()
@@ -85,6 +86,7 @@ func multiChannelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.
 				client = gossh.NewClient(ncc, chans, reqs)
 			}
 			if err != nil {
+				lch.Close()
 				return err
 			}
 			defer func() { _ = client.Close() }()

--- a/pkg/bastion/ssh.go
+++ b/pkg/bastion/ssh.go
@@ -90,7 +90,7 @@ func ChannelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewCh
 
 	switch actx.userType() {
 	case userTypeBastion:
-		log.Printf("New connection(bastion): sshUser=%q remote=%q local=%q dbUser=id:%q,email:%s", conn.User(), conn.RemoteAddr(), conn.LocalAddr(), actx.user.ID, actx.user.Email)
+		log.Printf("New connection(bastion): sshUser=%q remote=%q local=%q dbUser=id:%d,email:%s", conn.User(), conn.RemoteAddr(), conn.LocalAddr(), actx.user.ID, actx.user.Email)
 		host, err := dbmodels.HostByName(actx.db, actx.inputUsername)
 		if err != nil {
 			ch, _, err2 := newChan.Accept()


### PR DESCRIPTION
Hi @moul 

This PR fixes a little problem on the display of newly created bastion session:

`Jan 23 09:21:09 foosshportal1 c00617c0c9aa[1422]: 2019/01/23 08:21:09 New connection(bastion): sshUser="barfaz" remote="172.17.0.1:58570" local="172.17.0.3:2222" dbUser=id:'#',email:blabla@foobar.fr`

Here `dbUser` appears as the # character from ASCII table, as his id is 35.
I changed the format from %q to %d to fix the problem.

Another things that is included is this commit is the fix discussed by @kreanda in [#56](https://github.com/moul/sshportal/issues/56)
It was annoying to multiple people in the company and is imo a QOL improvement.

Do not hesitate to tell me if there's another way to do it :)

Thanks again for the great tool :) :100: 
