### PR TITLE
[fix] unable to use encrypted ssh private keys

### DIFF
--- a/pkg/bastion/ssh.go
+++ b/pkg/bastion/ssh.go
@@ -190,6 +190,9 @@ func ChannelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewCh
 func bastionClientConfig(ctx ssh.Context, host *dbmodels.Host) (*gossh.ClientConfig, error) {
 	actx := ctx.Value(authContextKey).(*authContext)
 
+	crypto.HostDecrypt(actx.aesKey, host)
+	crypto.SSHKeyDecrypt(actx.aesKey, host.SSHKey)
+	
 	clientConfig, err := host.ClientConfig(dynamicHostKey(actx.db, host))
 	if err != nil {
 		return nil, err
@@ -207,9 +210,6 @@ func bastionClientConfig(ctx ssh.Context, host *dbmodels.Host) (*gossh.ClientCon
 	if err2 != nil {
 		return nil, err2
 	}
-
-	crypto.HostDecrypt(actx.aesKey, host)
-	crypto.SSHKeyDecrypt(actx.aesKey, host.SSHKey)
 
 	switch action {
 	case string(dbmodels.ACLActionAllow):


### PR DESCRIPTION
This PR fixes a issue with encrypted sshkeys. If you are using AES encryption, you are not able to connect to hosts.
Error you are received:
error: ssh: no key found
Connection to sshportal closed.