### PR TITLE
Add username and session ID to session log filename.

### DIFF
--- a/pkg/bastion/ssh.go
+++ b/pkg/bastion/ssh.go
@@ -148,9 +148,8 @@ func ChannelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewCh
 				_ = ch.Close()
 				return
 			}
-
 			go func() {
-				err = multiChannelHandler(srv, conn, newChan, ctx, sessionConfigs)
+				err = multiChannelHandler(srv, conn, newChan, ctx, sessionConfigs, sess.ID)
 				if err != nil {
 					log.Printf("Error: %v", err)
 				}


### PR DESCRIPTION
This PR adds username and session ID to the tty session log filename. This makes it easier/quicker to find the person and session associated with it without having to look at sshportal logs or comparing dates in `session ls` output.