### PR TITLE
Set log files mode to 440 instead of 640.

### DIFF
--- a/pkg/bastion/session.go
+++ b/pkg/bastion/session.go
@@ -127,7 +127,7 @@ func pipe(lreqs, rreqs <-chan *gossh.Request, lch, rch gossh.Channel, logsLocati
 	channeltype := newChan.ChannelType()
 
 	filename := strings.Join([]string{logsLocation, "/", user, "-", username, "-", channeltype, "-", fmt.Sprint(sessionID), "-", time.Now().Format(time.RFC3339)}, "") // get user
-	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0440)
 	defer func() {
 		_ = f.Close()
 	}()


### PR DESCRIPTION
This PR just changes the mode on created tty log files. It seems to me it makes sense to have them set as read-only since they are audit files that usually have no reason to be altered outside of sshportal. This can help prevent mistakes (such as overwriting a log file by mistakenly using ttyrec on it instead of ttyplay, which happened to me).