### PR TITLE
Allow to create a host using an ip as name

### DIFF
--- a/pkg/bastion/shell.go
+++ b/pkg/bastion/shell.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -685,7 +686,16 @@ GLOBAL OPTIONS:
 						if c.String("password") != "" {
 							host.Password = c.String("password")
 						}
-						host.Name = strings.Split(host.Hostname(), ".")[0]
+						matched, err := regexp.MatchString(`^([0-9]{1,3}.){3}.([0-9]{1,3})$`, host.Hostname())
+						if err != nil {
+							return err
+						}
+						if matched {
+							host.Name = host.Hostname()
+						} else {
+							host.Name = strings.Split(host.Hostname(), ".")[0]
+						}
+
 						if c.String("hop") != "" {
 							hop, err := dbmodels.HostByName(db, c.String("hop"))
 							if err != nil {

--- a/pkg/dbmodels/dbmodels.go
+++ b/pkg/dbmodels/dbmodels.go
@@ -53,7 +53,7 @@ type SSHKey struct {
 type Host struct {
 	// FIXME: use uuid for ID
 	gorm.Model
-	Name     string       `gorm:"size:32" valid:"required,length(1|32),unix_user"`
+	Name     string       `gorm:"size:32" valid:"required,length(1|32)"`
 	Addr     string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL
 	User     string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL
 	Password string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL


### PR DESCRIPTION
This PR allows to create a host using an ip address as its name. This is sometimes useful when a host has no dns name and they're is no obvious way to name it other than by its address.

The PR does two things:
* remove the unix_user constraint on host names in dbmodels.go as it forbids to have a name starting with a number.
* add a check using a regex in shell.go to detect when the name is an ip (v4 only) and avoid splitting on "." in that case as that would make no sense.