### PR TITLE
Add Helm chart to deploy SSHPortal on Kubernetes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module moul.io/sshportal
 require (
 	cloud.google.com/go v0.40.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239
-	github.com/asaskevich/govalidator v0.0.0-20190528192650-f61b66f89f4a
-	github.com/denisenkom/go-mssqldb v0.0.0-20190528192650-eb9f6a1743f3 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+	github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
 	github.com/gliderlabs/ssh v0.2.2
@@ -20,11 +20,13 @@ require (
 	github.com/reiver/go-oi v0.0.0-20160325061615-431c83978379
 	github.com/reiver/go-telnet v0.0.0-20180421082511-9ff0b2ab096e
 	github.com/sabban/bastion v0.0.0-20180110125408-b9d3c9b1f4d3
-	github.com/smartystreets/assertions v0.0.0-20190528192650-f487f9de1cd3 // indirect
-	github.com/smartystreets/goconvey v0.0.0-20190528192650-68dc04aab96a
+	github.com/smartystreets/assertions v0.0.0-20190401211740-f487f9de1cd3 // indirect
+	github.com/smartystreets/goconvey v1.6.4-0.20190330032615-68dc04aab96a
 	github.com/urfave/cli v1.20.0
-	golang.org/x/crypto v0.0.0-20190614082836-5c40567a22f8
-	golang.org/x/sys v0.0.0-20190614082836-5ed2794edfdc // indirect
+	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
+	golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc // indirect
 	google.golang.org/appengine v1.6.1 // indirect
 	gopkg.in/gormigrate.v1 v1.5.0
 )
+
+go 1.12.6

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190528192650-f61b66f89f4a h1:yIrJuC1qNWAdlArS1a9jucA5nYzFRI6dehM7vpjL3kU=
 github.com/asaskevich/govalidator v0.0.0-20190528192650-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -21,6 +22,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f/go.mod h1:xN/JuLBIz4bjkxNmByTiV1IbhfnYb6oo99phBn4Eqhc=
+github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denisenkom/go-mssqldb v0.0.0-20190528192650-eb9f6a1743f3 h1:QJLPPsGf20+lPdQw+EBUc3xVzqBwNDsPBcnr5pCW7s8=
 github.com/denisenkom/go-mssqldb v0.0.0-20190528192650-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -124,10 +126,12 @@ github.com/sabban/bastion v0.0.0-20180110125408-b9d3c9b1f4d3 h1:yxUGvEatvDMO6gkh
 github.com/sabban/bastion v0.0.0-20180110125408-b9d3c9b1f4d3/go.mod h1:1Q04m7wmv/IMoZU9t8UkH+n9McWn4i3H9v9LnMgqloo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v0.0.0-20190401211740-f487f9de1cd3/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v0.0.0-20190528192650-f487f9de1cd3 h1:ObF780pbR2OP5tS/Hd8+yG2dQWxLzWe6FGRT4eZPA0M=
 github.com/smartystreets/assertions v0.0.0-20190528192650-f487f9de1cd3/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190528192650-68dc04aab96a h1:Lrry3qb+29a2vBtpCYZMRTd6FUsZi6fkeYWVsdlkYLQ=
 github.com/smartystreets/goconvey v0.0.0-20190528192650-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4-0.20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -142,6 +146,7 @@ golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190614082836-5c40567a22f8 h1:6HZxWy7rHlyxUWwYzid4tPCdV05RK9A1RD7eDTsaSsY=
 golang.org/x/crypto v0.0.0-20190614082836-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -178,6 +183,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190614082836-5ed2794edfdc h1:Tn4hxhC8ZV8oYgzx27sFCL4tC1bbazLSzRqw9plYpYQ=
 golang.org/x/sys v0.0.0-20190614082836-5ed2794edfdc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/helm/sshportal/.helmignore
+++ b/helm/sshportal/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/sshportal/Chart.yaml
+++ b/helm/sshportal/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: sshportal
+description: A Helm chart for SSHPortal on Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.10.0

--- a/helm/sshportal/templates/NOTES.txt
+++ b/helm/sshportal/templates/NOTES.txt
@@ -1,0 +1,33 @@
+1. Get the admin invitation token (only on first install):
+  export INVITE=$(kubectl --namespace sshportal logs -l "app.kubernetes.io/name={{ include "sshportal.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" | grep -Eo "invite:[a-zA-Z0-9]+")
+
+2. Get the service IP and Port:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sshportal.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "sshportal.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "sshportal.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "sshportal.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 2222:{{ .Values.service.port }}
+{{- end }}
+
+3. Enroll your SSH public key:
+{{- if contains "NodePort" .Values.service.type }}
+  ssh $NODE_IP -p $NODE_PORT -l $INVITE
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  ssh $SERVICE_IP -p {{ .Values.service.port }} -l $INVITE
+{{- else if contains "ClusterIP" .Values.service.type }}
+  ssh localhost -p 2222 -l $INVITE
+{{- end }}
+
+4. Configure your {{ include "sshportal.name" . }} install:
+{{- if contains "NodePort" .Values.service.type }}
+  ssh admin@$NODE_IP -p $NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  ssh admin@$SERVICE_IP -p {{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  ssh admin@localhost -p 2222
+{{- end }}

--- a/helm/sshportal/templates/_helpers.tpl
+++ b/helm/sshportal/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sshportal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sshportal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sshportal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "sshportal.labels" -}}
+helm.sh/chart: {{ include "sshportal.chart" . }}
+{{ include "sshportal.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sshportal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sshportal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sshportal.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sshportal.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/sshportal/templates/deployment.yaml
+++ b/helm/sshportal/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sshportal.fullname" . }}
+  labels:
+    {{- include "sshportal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sshportal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sshportal.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:v{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: ssh
+              containerPort: 2222
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - sshportal
+                - healthcheck
+                - --quiet
+          readinessProbe:
+            exec:
+              command:
+                - sshportal
+                - healthcheck
+                - --quiet
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+          {{- if .Values.mysql.enabled }}
+          - name: SSHPORTAL_DATABASE_URL
+            value: {{ .Values.mysql.user }}:{{ .Values.mysql.password }}@tcp({{ .Values.mysql.server }}:{{ .Values.mysql.port }})/{{ .Values.mysql.database }}?charset=utf8&parseTime=true&loc=Local
+          - name: SSHPORTAL_DB_DRIVER
+            value: mysql
+          {{- end }}
+          {{- if .Values.debug}}
+          - name: SSHPORTAL_DEBUG
+            value: "1"
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm/sshportal/templates/horizontal-pod-autoscaling.yaml
+++ b/helm/sshportal/templates/horizontal-pod-autoscaling.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sshportal.fullname" . }}
+  labels:
+    {{- include "sshportal.labels" . | nindent 4 }}
+spec:
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "sshportal.fullname" . }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.cpuTarget }}
+{{- end }}
+

--- a/helm/sshportal/templates/service.yaml
+++ b/helm/sshportal/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sshportal.fullname" . }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+  labels:
+    {{- include "sshportal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 2222
+      protocol: TCP
+      name: ssh
+  selector:
+    {{- include "sshportal.selectorLabels" . | nindent 4 }}

--- a/helm/sshportal/templates/tests/test-connection.yaml
+++ b/helm/sshportal/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "sshportal.fullname" . }}-test-connection"
+  labels:
+{{ include "sshportal.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "sshportal.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/sshportal/values.yaml
+++ b/helm/sshportal/values.yaml
@@ -1,0 +1,119 @@
+# Default values for sshportal.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## Enable SSHPortal debug mode
+##
+debug: false
+
+## SSH Portal Docker image
+##
+image:
+  repository: moul/sshportal
+  pullPolicy: IfNotPresent
+
+## Reference to one or more secrets to be used when pulling images
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+imagePullSecrets: []
+
+## Provide a name in place of sshportal for `app:` labels
+##
+nameOverride: ""
+
+## Provide a name to substitute for the full names of resources
+##
+fullnameOverride: ""
+
+## PodSecurityContext holds pod-level security attributes.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+podSecurityContext: {}
+  # fsGroup: 2000
+
+## SecurityContext holds container-level security attributes.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## Service
+##
+service:
+  ## Configure additional annotations for SSHPortal service
+  ##
+  annotations: {}
+    # service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+
+  ## Service type, one of
+  ## NodePort, ClusterIP, LoadBalancer
+  ##
+  type: LoadBalancer
+
+  ## Port to expose on the service
+  ##
+  port: 22
+
+## Define resources requests and limits
+## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # limits:
+  #   cpu: 2
+  #   memory: 2Gi
+
+## Mysql/MariaDB configuration for HA
+##
+mysql:
+  enabled: false
+
+  ## Database user
+  ##
+  user: sshportal
+
+  ## Database password
+  ##
+  password: change_me
+
+  ## Database name
+  ##
+  database: sshportal
+
+  ## Database server FQDN or IP
+  ##
+  server: mariadb-mariadb-galera
+
+  ## Database port
+  ##
+  port: 3306
+
+## Define which Nodes the Pods are scheduled on.
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## The pod's tolerations.
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Assign custom affinity rules
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+affinity: {}
+
+## HPA support, require `mysql.enable: true`
+## This section enables sshportal to autoscale based on metrics.
+##
+autoscaling:
+  maxReplicas: 4
+  minReplicas: 2
+  cpuTarget: 60


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Helm chart to deploy SSHPortal on Kubernetes.
The chart support HA and standalone configuration.

**Which issue this PR fixes**:

N/A

**Special notes for your reviewer**: