### PR TITLE
Update README.md; Info about missing host keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Shared connection to localhost closed.
 $
 ```
 
+If the association fails and you are promted for a password, verify that the host you're connecting from has a SSH key set up or generate one with ```ssh-keygen -t rsa```
+
 Drop an interactive administrator shell
 
 ```console


### PR DESCRIPTION
**What this PR does / why we need it:**
Current readme does not inform user of how to fix the behaviour of password promt when linking admin account

**Which issue this PR fixes: fixes #128**
Updated the readme to inform the user of a quick fix (ssh-keygen -t rsa) when association fails and user is asked for password
