### PR TITLE
Fix early closure of data stream.

### DIFF
--- a/pkg/bastion/session.go
+++ b/pkg/bastion/session.go
@@ -201,7 +201,7 @@ func pipe(lreqs, rreqs <-chan *gossh.Request, lch, rch gossh.Channel, logsLocati
 		quit <- "rreqs"
 	}(quit)
 
-	lchEof, rchEof, lchClosed, rchClosed := false, false, false, false
+	lchEOF, rchEOF, lchClosed, rchClosed := false, false, false, false
 	for {
 		select {
 		case err := <-errch:
@@ -209,10 +209,10 @@ func pipe(lreqs, rreqs <-chan *gossh.Request, lch, rch gossh.Channel, logsLocati
 		case q := <-quit:
 			switch q {
 			case "lch":
-				lchEof = true
+				lchEOF = true
 				_ = rch.CloseWrite()
 			case "rch":
-				rchEof = true
+				rchEOF = true
 				_ = lch.CloseWrite()
 			case "lreqs":
 				lchClosed = true
@@ -220,15 +220,15 @@ func pipe(lreqs, rreqs <-chan *gossh.Request, lch, rch gossh.Channel, logsLocati
 				rchClosed = true
 			}
 
-			if lchEof && lchClosed && !rchClosed {
+			if lchEOF && lchClosed && !rchClosed {
 				rch.Close()
 			}
 
-			if rchEof && rchClosed && !lchClosed {
+			if rchEOF && rchClosed && !lchClosed {
 				lch.Close()
 			}
 
-			if lchEof && rchEof && lchClosed && rchClosed {
+			if lchEOF && rchEOF && lchClosed && rchClosed {
 				return nil
 			}
 		}

--- a/pkg/bastion/ssh.go
+++ b/pkg/bastion/ssh.go
@@ -160,8 +160,7 @@ func ChannelHandler(srv *ssh.Server, conn *gossh.ServerConn, newChan gossh.NewCh
 					ErrMsg:    fmt.Sprintf("%v", err),
 					StoppedAt: &now,
 				}
-				switch sessUpdate.ErrMsg {
-				case "lch closed the connection", "rch closed the connection":
+				if err == nil {
 					sessUpdate.ErrMsg = ""
 				}
 				actx.db.Model(&sess).Updates(&sessUpdate)


### PR DESCRIPTION

**What this PR does / why we need it**:

In the current implementation, usage of an inline shell command through SSH is broken (see #55 and #127).
This bug prevents usage of sshportal with CI and automation tools (jenkins, ansible etc...).

This issue is due to some race conditions in the go subroutines leading to:
* early quit because a SSH_MSG_CHANNNEL_CLOSE packet was processed by the main function but EOF wasn't read yet by the subroutine in the data stream
* early quit because the subroutine reading the data stream reached EOF but the main function didn't process yet the last packets in the requests channel (SSH_MSG_CHANNEL_REQUEST/exit-status and SSH_MSG_CHANNNEL_CLOSE)

Because of this race condition, the following can happen:
* Output of the inline shell command isn't copied from rch to lch
* exit-status isn't copied from rch to lch
* lch doesn't receive SSH_MSG_CHANNNEL_EOF packet

This PR fixes this issue by requesting that EOF is readed in the data stream AND the requests channel is closed on one side before starting closing everything.

**Which issue this PR fixes**: 

Fixes moul/sshportal#55 and Fixes moul/sshportal#127
