### PR TITLE
fix: increase size of name fields

### DIFF
--- a/pkg/dbmodels/dbmodels.go
+++ b/pkg/dbmodels/dbmodels.go
@@ -38,7 +38,7 @@ type Setting struct {
 type SSHKey struct {
 	// FIXME: use uuid for ID
 	gorm.Model
-	Name        string  `valid:"required,length(1|32),unix_user"`
+	Name        string  `valid:"required,length(1|255),unix_user"`
 	Type        string  `valid:"required"`
 	Length      uint    `valid:"required"`
 	Fingerprint string  `valid:"optional"`
@@ -51,7 +51,7 @@ type SSHKey struct {
 type Host struct {
 	// FIXME: use uuid for ID
 	gorm.Model
-	Name     string       `gorm:"size:32" valid:"required,length(1|32)"`
+	Name     string       `gorm:"size:255" valid:"required,length(1|255)"`
 	Addr     string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL
 	User     string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL
 	Password string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL
@@ -78,7 +78,7 @@ type UserKey struct {
 
 type UserRole struct {
 	gorm.Model
-	Name  string  `valid:"required,length(1|32),unix_user"`
+	Name  string  `valid:"required,length(1|255),unix_user"`
 	Users []*User `gorm:"many2many:user_user_roles"`
 }
 
@@ -87,7 +87,7 @@ type User struct {
 	gorm.Model
 	Roles       []*UserRole  `gorm:"many2many:user_user_roles"`
 	Email       string       `valid:"required,email"`
-	Name        string       `valid:"required,length(1|32),unix_user"`
+	Name        string       `valid:"required,length(1|255),unix_user"`
 	Keys        []*UserKey   `gorm:"ForeignKey:UserID"`
 	Groups      []*UserGroup `gorm:"many2many:user_user_groups;"`
 	Comment     string       `valid:"optional"`
@@ -96,7 +96,7 @@ type User struct {
 
 type UserGroup struct {
 	gorm.Model
-	Name    string  `valid:"required,length(1|32),unix_user"`
+	Name    string  `valid:"required,length(1|255),unix_user"`
 	Users   []*User `gorm:"many2many:user_user_groups;"`
 	ACLs    []*ACL  `gorm:"many2many:user_group_acls;"`
 	Comment string  `valid:"optional"`
@@ -104,7 +104,7 @@ type UserGroup struct {
 
 type HostGroup struct {
 	gorm.Model
-	Name    string  `valid:"required,length(1|32),unix_user"`
+	Name    string  `valid:"required,length(1|255),unix_user"`
 	Hosts   []*Host `gorm:"many2many:host_host_groups;"`
 	ACLs    []*ACL  `gorm:"many2many:host_group_acls;"`
 	Comment string  `valid:"optional"`


### PR DESCRIPTION
We use format "username:hostname" as hostname for some of our servers. In sometimes we get error:
```
error: Name: server.name:sergey.yashchuk does not validate as length(1|32)
```

As I can see in database fields have length 255 symbols already (not sure how's it in MySQL):
```
# sqlite3 sshportal.db

SQLite version 3.22.0 2018-01-22 18:45:57
Enter ".help" for usage hints.

sqlite> .tables
acls              hosts             user_group_acls   user_user_roles
events            migrations        user_groups       users
host_group_acls   sessions          user_keys
host_groups       settings          user_roles
host_host_groups  ssh_keys          user_user_groups

sqlite> .schema hosts
CREATE TABLE IF NOT EXISTS "hosts" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"deleted_at" datetime,"name" varchar(32),"addr" varchar(255),"user" varchar(255),"password" varchar(255),"ssh_key_id" integer,"fingerprint" varchar(255),"comment" varchar(255) , "host_key" blob, "url" varchar(255), "hop_id" integer, "logging" varchar(255));
CREATE INDEX idx_hosts_deleted_at ON "hosts"(deleted_at) ;
CREATE INDEX idx_hosts_ssh_key_id ON "hosts"(ssh_key_id) ;
CREATE UNIQUE INDEX uix_hosts_name ON "hosts"("name") ;
```
So don't need to recreate or update DB.

Updated fields length in my PR, builded, checked - no issues.

Also this fix can close this old issue:
https://github.com/moul/sshportal/issues/61

fixes #61