### PR TITLE
feat: Allow removal by user for 'userkey rm'

### DIFF
--- a/pkg/bastion/shell.go
+++ b/pkg/bastion/shell.go
@@ -2132,7 +2132,16 @@ GLOBAL OPTIONS:
 						if err := myself.CheckRoles([]string{"admin"}); err != nil {
 							return err
 						}
-
+						if err := dbmodels.UserKeysByIdentifiers(db, c.Args()).Find(&dbmodels.UserKey{}).Error; err != nil {
+							var user dbmodels.User
+							if err := dbmodels.UsersByIdentifiers(db, c.Args()).First(&user).Error; err != nil {
+								return err
+							}
+							if err := dbmodels.UserKeysByUserID(db, []string{fmt.Sprint(user.ID)}).Find(&dbmodels.UserKey{}).Error; err != nil {
+								return err
+							}
+							return dbmodels.UserKeysByUserID(db, []string{fmt.Sprint(user.ID)}).Delete(&dbmodels.UserKey{}).Error
+						}
 						return dbmodels.UserKeysByIdentifiers(db, c.Args()).Delete(&dbmodels.UserKey{}).Error
 					},
 				},

--- a/pkg/dbmodels/dbmodels.go
+++ b/pkg/dbmodels/dbmodels.go
@@ -371,6 +371,9 @@ func UserKeysPreload(db *gorm.DB) *gorm.DB {
 func UserKeysByIdentifiers(db *gorm.DB, identifiers []string) *gorm.DB {
 	return db.Where("id IN (?)", identifiers)
 }
+func UserKeysByUserID(db *gorm.DB, identifiers []string) *gorm.DB {
+	return db.Where("user_id IN (?)", identifiers)
+}
 
 // UserRole helpers
 


### PR DESCRIPTION
The userkey rm command implies that it can remove a key by user or the
id key, but it only works against the data base id of the key.  This
patch allows the userkey rm command to work with the user name, so
that all the keys for the user can be cleared out in one command.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>