### PR TITLE
fix: host inspect causes db errors with later operations

### DIFF
--- a/pkg/bastion/shell.go
+++ b/pkg/bastion/shell.go
@@ -828,12 +828,14 @@ GLOBAL OPTIONS:
 						}
 
 						var hosts []*dbmodels.Host
-						db = db.Preload("Groups")
 						if myself.HasRole("admin") {
-							db = db.Preload("SSHKey")
-						}
-						if err := dbmodels.HostsByIdentifiers(db, c.Args()).Find(&hosts).Error; err != nil {
-							return err
+							if err := dbmodels.HostsByIdentifiers(db.Preload("Groups").Preload("SSHKey"), c.Args()).Find(&hosts).Error; err != nil {
+								return err
+							}
+						} else {
+							if err := dbmodels.HostsByIdentifiers(db.Preload("Groups"), c.Args()).Find(&hosts).Error; err != nil {
+								return err
+							}
 						}
 
 						if c.Bool("decrypt") {


### PR DESCRIPTION
The most simple case with a fresh install of sshportal using the
following commands put the shell into a unrecoverable state.

```console
config> host create test1@test1
1
config> host inspect 1
config> host create test2@test2
error: can't preload field Groups for dbmodels.SSHKey
```


The issue is caused because the global db handle is replaced with the
inspect command.