### PR TITLE
feat: "user rm" also removes the user sshkeys

### DIFF
--- a/pkg/bastion/shell.go
+++ b/pkg/bastion/shell.go
@@ -1716,7 +1716,7 @@ GLOBAL OPTIONS:
 					},
 				}, {
 					Name:      "rm",
-					Usage:     "Removes one or more users",
+					Usage:     "Removes one or more users and the user ssh keys",
 					ArgsUsage: "USER...",
 					Action: func(c *cli.Context) error {
 						if c.NArg() < 1 {
@@ -1727,6 +1727,12 @@ GLOBAL OPTIONS:
 							return err
 						}
 
+						var users []dbmodels.User
+						if err := dbmodels.UsersPreload(dbmodels.UsersByIdentifiers(db, c.Args())).Find(&users).Error; err == nil {
+							for _, user := range users {
+								dbmodels.UserKeysByUserID(db, []string{fmt.Sprint(user.ID)}).Delete(&dbmodels.UserKey{})
+							}
+						}
 						return dbmodels.UsersByIdentifiers(db, c.Args()).Delete(&dbmodels.User{}).Error
 					},
 				}, {


### PR DESCRIPTION
There is no easy way to remove all the end users ssh key after
removing an end user.  The "user rm" should remove all the
ssh keys at the time the end user is removed.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes**: fixes #xxx, fixes #xxx...

**Special notes for your reviewer**:
